### PR TITLE
Add borrow fee tracking and signal

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -827,7 +827,15 @@ class BaseAgent(ABC):
     def record_payment(self, account: str, amount: float,
                        payment_type: Literal['interest', 'dividend', 'trade', 'borrow_fee', 'other'],
                        round_number: int):
-        """Record a payment in the agent's history"""
+        """Record a payment in the agent's history.
+
+        Args:
+            account: Account affected ("main" or "dividend").
+            amount: Payment amount. Negative values represent cash outflows,
+                such as dividend obligations on short positions.
+            payment_type: Type of payment.
+            round_number: Simulation round when the payment occurred.
+        """
         payment = Payment(
             round_number=round_number,
             amount=amount,

--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -20,7 +20,7 @@ class Payment:
     round_number: int
     amount: float
     account: str
-    payment_type: Literal['interest', 'dividend', 'trade', 'other']
+    payment_type: Literal['interest', 'dividend', 'trade', 'borrow_fee', 'other']
 
 class BaseAgent(ABC):
     """Base agent with core functionality"""
@@ -103,6 +103,7 @@ class BaseAgent(ABC):
             'interest': [],
             'dividend': [],
             'trade': [],
+            'borrow_fee': [],
             'other': []
         }
 
@@ -823,9 +824,9 @@ class BaseAgent(ABC):
         """Get total available cash (main account, dividend account is not for trading)"""
         return self.cash
 
-    def record_payment(self, account: str, amount: float, 
-                      payment_type: Literal['interest', 'dividend', 'trade', 'other'], 
-                      round_number: int):
+    def record_payment(self, account: str, amount: float,
+                       payment_type: Literal['interest', 'dividend', 'trade', 'borrow_fee', 'other'],
+                       round_number: int):
         """Record a payment in the agent's history"""
         payment = Payment(
             round_number=round_number,

--- a/src/market/information/information_providers.py
+++ b/src/market/information/information_providers.py
@@ -63,6 +63,24 @@ class InterestProvider(BaseProvider):
             }
         )
 
+
+class BorrowRateProvider(BaseProvider):
+    def generate_signal(self, round_number: int) -> InformationSignal:
+        state = self.market_state
+        borrow_state = state['borrow']
+
+        return InformationSignal(
+            type=InformationType.BORROW_FEE,
+            value=borrow_state['rate'],
+            reliability=self.config.reliability,
+            metadata={
+                'round': round_number,
+                'payment_frequency': borrow_state['payment_frequency'],
+                'last_payment': borrow_state.get('last_payment'),
+                'next_payment_round': borrow_state.get('next_payment_round')
+            }
+        )
+
 class OrderBookProvider(BaseProvider):
     def generate_signal(self, round_number: int) -> InformationSignal:
         state = self.market_state

--- a/src/market/information/information_types.py
+++ b/src/market/information/information_types.py
@@ -10,6 +10,7 @@ class InformationType(Enum):
     FUNDAMENTAL = "fundamental"
     DIVIDEND = "dividend"
     INTEREST = "interest"
+    BORROW_FEE = "borrow_fee"
     INSIDER = "insider"
 
 class SignalCategory(Enum):
@@ -49,6 +50,7 @@ SIGNAL_CATEGORIES = {
     InformationType.FUNDAMENTAL: SignalCategory.FUNDAMENTAL,
     InformationType.DIVIDEND: SignalCategory.FUNDAMENTAL,
     InformationType.INTEREST: SignalCategory.PUBLIC,
+    InformationType.BORROW_FEE: SignalCategory.PUBLIC,
     InformationType.INSIDER: SignalCategory.RESTRICTED
 }
 

--- a/src/market/state/services/borrow_service.py
+++ b/src/market/state/services/borrow_service.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+from services.logging_service import LoggingService
+
+
+@dataclass
+class BorrowFeeResult:
+    success: bool
+    message: str
+    total_fee: float
+    num_accounts_charged: int
+
+
+class BorrowService:
+    """Service to handle borrow fee calculations and payments"""
+
+    def __init__(self, agent_repository, logger, borrow_params):
+        self.agent_repository = agent_repository
+
+        if not borrow_params:
+            raise ValueError("borrow_params is required")
+
+        self.borrow_model = borrow_params
+        self.borrow_history = []
+        self.current_round = 0
+        self.next_payment_round = self.borrow_model.get('payment_frequency', 1)
+
+    def calculate_fee(self, borrowed_shares: float, price: float) -> float:
+        """Calculate borrow fee for a position"""
+        return borrowed_shares * self.borrow_model['rate'] * price
+
+    def process_borrow_fees(self, round_number: int, price: float) -> BorrowFeeResult:
+        """Process borrow fee payments for all agents"""
+        frequency = self.borrow_model.get('payment_frequency', 1)
+        if round_number % frequency != 0:
+            return BorrowFeeResult(True, "No borrow fees this round", 0.0, 0)
+
+        total_fee = 0.0
+        num_agents = 0
+
+        for agent_id in self.agent_repository.get_all_agent_ids():
+            agent = self.agent_repository.get_agent(agent_id)
+            if agent.borrowed_shares > 0:
+                fee = self.calculate_fee(agent.borrowed_shares, price)
+                if fee > 0:
+                    self.agent_repository.update_account_balance(
+                        agent_id=agent_id,
+                        amount=-fee,
+                        account_type='main',
+                        payment_type='borrow_fee',
+                        round_number=round_number
+                    )
+                    total_fee += fee
+                    num_agents += 1
+
+        self.borrow_history.append(total_fee)
+        LoggingService.get_logger('borrow').info(
+            f"\n=== Round {round_number} Borrow Fees ==="\
+            f"\nRate: {self.borrow_model['rate']:.1%}"\
+            f"\nTotal Fees: ${total_fee:.2f}"
+        )
+
+        return BorrowFeeResult(
+            success=True,
+            message="Borrow fees processed successfully",
+            total_fee=total_fee,
+            num_accounts_charged=num_agents
+        )
+
+    def get_current_rate(self) -> float:
+        """Get current borrow fee rate"""
+        return self.borrow_model['rate']
+
+    def get_state(self) -> dict:
+        """Get current borrow fee state"""
+        return {
+            'rate': self.get_current_rate(),
+            'payment_frequency': self.borrow_model.get('payment_frequency', 1),
+            'last_payment': self.borrow_history[-1] if self.borrow_history else None,
+            'next_payment_round': self.next_payment_round
+        }
+
+    def update(self, round_number: int):
+        """Update state for current round"""
+        self.current_round = round_number
+        frequency = self.borrow_model.get('payment_frequency', 1)
+        self.next_payment_round = (
+            round_number + (frequency - (round_number % frequency))
+            if round_number % frequency != 0
+            else round_number + frequency
+        )


### PR DESCRIPTION
## Summary
- add BorrowService to calculate and deduct borrow fees
- track borrow-fee payments on agents
- broadcast borrow fee rate via new market information signal

## Testing
- `python -m py_compile src/agents/base_agent.py src/base_sim.py src/market/information/information_providers.py src/market/information/information_types.py src/market/state/market_state_manager.py src/market/state/services/borrow_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab4546a240832f9f7cf06d5c7b3bde