### PR TITLE
Add borrowing logger support and fix short selling edge cases

### DIFF
--- a/src/market/state/services/dividend_service.py
+++ b/src/market/state/services/dividend_service.py
@@ -70,7 +70,9 @@ class DividendPaymentProcessor:
 
         for agent_id in self.agent_repository.get_all_agent_ids():
             agent = self.agent_repository.get_agent(agent_id)
-            state = self.agent_repository.get_agent_state_snapshot(agent_id, 0)
+            state = self.agent_repository.get_agent_state_snapshot(
+                agent_id, self.agent_repository.context.current_price
+            )
 
             # Net share position accounts for short holdings
             net_position = agent.total_shares - agent.borrowed_shares
@@ -118,7 +120,9 @@ class DividendPaymentProcessor:
         total_payment = 0
         
         for agent_id in self.agent_repository.get_all_agent_ids():
-            state = self.agent_repository.get_agent_state_snapshot(agent_id, 0)
+            state = self.agent_repository.get_agent_state_snapshot(
+                agent_id, self.agent_repository.context.current_price
+            )
             if state.total_shares > 0:
                 payment = redemption_value * state.total_shares
                 total_shares += state.total_shares

--- a/src/scenarios.py
+++ b/src/scenarios.py
@@ -348,7 +348,7 @@ SCENARIOS = {
             "INITIAL_PRICE": 28.0,
             # Fundamental calculated as E(d)/r
             "AGENT_PARAMS": {
-                'allow_short_selling': False,  # Change when short selling is implemented
+                'allow_short_selling': True,
                 'position_limit': 100000000,
                 'initial_cash': BASE_INITIAL_CASH,
                 'initial_shares': BASE_INITIAL_SHARES,
@@ -429,7 +429,7 @@ SCENARIOS = {
             "INITIAL_PRICE": 2*FUNDAMENTAL_WITH_DEFAULT_PARAMS,
             # Fundamental calculated as E(d)/r
             "AGENT_PARAMS": {
-                'allow_short_selling': False, # Change when short selling is implemented
+                'allow_short_selling': True,
                 'position_limit': BASE_POSITION_LIMIT,
                 'initial_cash': BASE_INITIAL_CASH,
                 'initial_shares': int(0.5 * BASE_INITIAL_SHARES),
@@ -472,7 +472,7 @@ SCENARIOS = {
             "INITIAL_PRICE": round(FUNDAMENTAL_WITH_DEFAULT_PARAMS/2, 2),
             # Fundamental calculated as E(d)/r
             "AGENT_PARAMS": {
-                'allow_short_selling': False, # Change when short selling is implemented
+                'allow_short_selling': True,
                 'position_limit': BASE_POSITION_LIMIT,
                 'initial_cash': BASE_INITIAL_CASH,
                 'initial_shares': int(0.5 * BASE_INITIAL_SHARES),
@@ -577,7 +577,7 @@ SCENARIOS = {
             "INITIAL_PRICE": FUNDAMENTAL_WITH_DEFAULT_PARAMS,
             "HIDE_FUNDAMENTAL_PRICE": True,
             "AGENT_PARAMS": {
-                'allow_short_selling': False, # Change when short selling is implemented
+                'allow_short_selling': True,
                 'position_limit': BASE_POSITION_LIMIT,
                 'initial_cash': BASE_INITIAL_CASH,
                 'initial_shares': BASE_INITIAL_SHARES,

--- a/src/services/logging_service.py
+++ b/src/services/logging_service.py
@@ -73,6 +73,8 @@ class LoggingService:
         cls._setup_order_book_logger(console_handler)
         cls._setup_interest_logger(console_handler)
         cls._setup_dividend_logger(console_handler)
+        cls._setup_borrow_logger(console_handler)
+        cls._setup_borrowing_logger(console_handler)
         cls._setup_verification_logger(console_handler)
         cls._setup_margin_call_logger(console_handler)
 
@@ -268,6 +270,16 @@ class LoggingService:
         dividend_logger.addHandler(file_handler)
         dividend_logger.addHandler(console_handler)
         cls._loggers['dividend'] = dividend_logger
+
+    @classmethod
+    def _setup_borrow_logger(cls, console_handler):
+        """Setup borrow fee logger"""
+        cls._setup_logger('borrow', console_handler, 'borrow.log')
+
+    @classmethod
+    def _setup_borrowing_logger(cls, console_handler):
+        """Setup share borrowing logger"""
+        cls._setup_logger('borrowing', console_handler, 'borrowing.log')
 
     @classmethod
     def _setup_verification_logger(cls, console_handler):


### PR DESCRIPTION
## Summary
- Initialize `borrow` and `borrowing` loggers so short selling infrastructure has required logging channels
- Use current market price when processing dividends and redemptions to avoid divide-by-zero margin checks
- Enable short selling in several predefined scenarios that were previously stubbed out

## Testing
- `pytest -q`
- `python - <<'PY'
import sys; sys.path.append('src'); from base_sim import BaseSimulation
params={'allow_short_selling':True,'margin_requirement':0.5,'borrow_model':{'rate':0.0,'payment_frequency':1},'position_limit':1000000,'initial_cash':50000.0,'initial_shares':0,'max_order_size':500,'agent_composition':{'short_sell_trader':1,'buy_trader':1},'deterministic_params':{}}
sim=BaseSimulation(num_rounds=1,initial_price=100,fundamental_price=100,redemption_value=100,transaction_cost=0,lendable_shares=1000,agent_params=params,dividend_params={'type':'stochastic','base_dividend':0,'dividend_frequency':1,'dividend_growth':0,'dividend_probability':0,'dividend_variation':0,'destination':'dividend'},interest_params={'rate':0.0,'compound_frequency':1,'destination':'dividend'},borrow_params={'rate':0.0,'payment_frequency':1},infinite_rounds=False,sim_type='deterministic_short_trade')
sim.run()
for agent_id in sim.agent_repository.get_all_agent_ids():
    state = sim.agent_repository.get_agent_state_snapshot(agent_id, sim.context.current_price)
    print(agent_id, state.cash, state.shares, state.borrowed_shares)
PY`

------
https://chatgpt.com/codex/tasks/task_b_68ac71191928832fa4caa97478cc2fd0