### PR TITLE
Enable short selling across prompts and agents

### DIFF
--- a/src/agents/LLMs/llm_prompt_templates.py
+++ b/src/agents/LLMs/llm_prompt_templates.py
@@ -12,8 +12,8 @@ Trading Options:
    - For each order:
      - Market order: Set order_type='market'
      - Limit order: Set order_type='limit' and specify price_limit
-   - IMPORTANT: Sell orders require sufficient available shares
-   - Short selling is NOT allowed
+   - IMPORTANT: Sell orders may require borrowing shares if you don't hold enough
+   - Short selling is allowed when borrowing is available
 
 2. Cancel Orders (replace_decision='Cancel'):
    - Return an empty orders list: orders=[]
@@ -31,10 +31,10 @@ Your decision must include:
 
 POSITION_INFO_TEMPLATE = """
 Your Position:
-- Available Shares: {shares} shares (Short selling is not allowed)
+- Available Shares: {shares} shares (negative indicates a short position)
 - Main Cash Account: ${cash:.2f}
 - Dividend Cash Account (not available for trading): ${dividend_cash:.2f}
-- Total Available Cash: ${total_available_cash:.2f} (Borrowing is not allowed)
+- Total Available Cash: ${total_available_cash:.2f} (Cash borrowing is not allowed)
 - Shares in Orders: {committed_shares} shares
 - Cash in Orders: ${committed_cash:.2f}
 """

--- a/src/agents/agent_types.py
+++ b/src/agents/agent_types.py
@@ -188,7 +188,7 @@ AGENT_TYPES = {
 
         Your profit comes from capturing the spread between bid and ask prices, not from directional price movement.
 
-        IMPORTANT: There is NO SHORT SELLING allowed. You can only sell shares you already own.
+        Short selling is permitted when shares can be borrowed. Manage both long and short inventory carefully.
 
         Trading Guidelines:
         - Place LIMIT buy orders slightly below the current market price (1-3% lower)
@@ -197,17 +197,14 @@ AGENT_TYPES = {
         - NEVER place sell orders more than 10% above your buy orders
         - Adjust your spread width based on recent price volatility
 
-        Inventory Management (No Short Selling):
-        - Monitor your current inventory in the market data
-        - Only place sell orders for quantities you actually own
-        - If you have no inventory, focus on buy orders first
-        - As you acquire inventory, gradually place sell orders
-        - If inventory grows too large, reduce or pause buy orders
-        - Adjust your buy/sell ratio based on current inventory level
-        
-        Example: If price = $100, you might place buy orders at $97-99 and sell orders at $101-103,
-        but limit your sell quantity to what you currently own.
-        
+        Inventory Management:
+        - Monitor your current inventory including borrowed shares
+        - You may sell shares you do not own by borrowing them when available
+        - If inventory grows too large in either direction, adjust your orders
+        - Balance buy and sell orders based on current net position
+
+        Example: If price = $100, you might place buy orders at $97-99 and sell orders at $101-103.
+
         Remember that extreme spreads (e.g., buying at $3 and selling at $30) will not execute and will lead to losses.""",
         user_prompt_template=STANDARD_USER_TEMPLATE,
         type_id="market_maker"

--- a/src/agents/deterministic/hold_agent.py
+++ b/src/agents/deterministic/hold_agent.py
@@ -8,9 +8,14 @@ class HoldTrader(BaseAgent):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def make_decision(self, market_state: Dict, history: List, round_number: int) -> Dict:
+    def make_decision(self, market_state: Dict, history: List, round_number: int) -> TradeDecision:
+        current_price = market_state.get('price', 0)
         return TradeDecision(
-            decision="Hold",
-            quantity=0,
-            reasoning="Always hold strategy"
-        ).model_dump()
+            orders=[],
+            replace_decision="Add",
+            reasoning="Always hold strategy",
+            valuation=current_price,
+            valuation_reasoning="Using current price as valuation baseline",
+            price_target=current_price,
+            price_target_reasoning="No expected price change",
+        )

--- a/src/agents/deterministic/market_maker_sell.py
+++ b/src/agents/deterministic/market_maker_sell.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 from agents.base_agent import BaseAgent
-from agents.agents_api import TradeDecision, OrderType
+from agents.agents_api import TradeDecision, OrderType, OrderDetails
 
 class MarketMakerSell(BaseAgent):
     """Market maker that places sell orders based on fundamental value"""
@@ -32,42 +32,58 @@ class MarketMakerSell(BaseAgent):
         
         return price * (1 + final_markup)
 
-    def make_decision(self, market_state: Dict, history: List, round_number: int) -> Dict:
+    def make_decision(self, market_state: Dict, history: List, round_number: int) -> TradeDecision:
         price = market_state['price']
         fundamental = market_state.get('fundamental_price', price)
         current_position = self.shares
-        
+
         # Only sell if we have shares above the position limit (0 or negative)
         if current_position > self.position_limit:
             # Calculate ask price
             ask_price = self.calculate_ask_price(price, fundamental)
-            
+
             # Check available shares
             available_shares = self.available_shares
             if available_shares == 0:
                 return TradeDecision(
-                    decision="Hold",
-                    quantity=0,
-                    reasoning="Insufficient shares for trade"
-                ).model_dump()
-            
+                    orders=[],
+                    replace_decision="Add",
+                    reasoning="Insufficient shares for trade",
+                    valuation=fundamental,
+                    valuation_reasoning="Fundamental estimate provided",
+                    price_target=price,
+                    price_target_reasoning="Cannot participate",
+                )
+
             # Adjust order size based on remaining position capacity
             sell_size = min(
                 self.order_size,
                 current_position - self.position_limit,
                 available_shares
             )
-            
-            return TradeDecision(
+
+            order = OrderDetails(
                 decision="Sell",
                 quantity=sell_size,
                 order_type=OrderType.LIMIT,
                 price_limit=ask_price,
-                reasoning=f"Making market: Ask ${ask_price:.2f} (fundamental: ${fundamental:.2f})"
-            ).model_dump()
-        
+            )
+            return TradeDecision(
+                orders=[order],
+                replace_decision="Replace",
+                reasoning=f"Making market: Ask ${ask_price:.2f} (fundamental: ${fundamental:.2f})",
+                valuation=fundamental,
+                valuation_reasoning="Fundamental estimate provided",
+                price_target=fundamental,
+                price_target_reasoning="Target aligns with fundamental",
+            )
+
         return TradeDecision(
-            decision="Hold",
-            quantity=0,
-            reasoning="At position limit"
-        ).model_dump()
+            orders=[],
+            replace_decision="Add",
+            reasoning="At position limit",
+            valuation=fundamental,
+            valuation_reasoning="Fundamental estimate provided",
+            price_target=price,
+            price_target_reasoning="No trade executed",
+        )

--- a/src/agents/deterministic/mean_reversion_trader.py
+++ b/src/agents/deterministic/mean_reversion_trader.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 from agents.base_agent import BaseAgent
-from agents.agents_api import TradeDecision, OrderType
+from agents.agents_api import TradeDecision, OrderType, OrderDetails
 
 class MeanReversionTrader(BaseAgent):
     """Trades based on deviations from moving average"""
@@ -23,66 +23,97 @@ class MeanReversionTrader(BaseAgent):
         recent_prices = [h['price'] for h in history[-self.window_size:]]
         return sum(recent_prices) / len(recent_prices)
 
-    def make_decision(self, market_state: Dict, history: List, round_number: int) -> Dict:
+    def make_decision(self, market_state: Dict, history: List, round_number: int) -> TradeDecision:
+        current_price = market_state['price']
+
         if len(history) < 2:  # Need at least 2 data points
             return TradeDecision(
-                decision="Hold",
-                quantity=0,
-                reasoning="Insufficient history for mean reversion"
-            ).model_dump()
+                orders=[],
+                replace_decision="Add",
+                reasoning="Insufficient history for mean reversion",
+                valuation=current_price,
+                valuation_reasoning="Using current price as valuation baseline",
+                price_target=current_price,
+                price_target_reasoning="No historical data",
+            )
 
-        current_price = market_state['price']
         moving_avg = self.calculate_moving_average(history)
-        
+
         # Calculate deviation as percentage
         deviation = (current_price - moving_avg) / moving_avg
-        
+
         # If deviation is too small, hold
         if abs(deviation) < self.threshold:
             return TradeDecision(
-                decision="Hold",
-                quantity=0,
-                reasoning="Price near moving average"
-            ).model_dump()
-        
+                orders=[],
+                replace_decision="Add",
+                reasoning="Price near moving average",
+                valuation=current_price,
+                valuation_reasoning="Using current price as valuation baseline",
+                price_target=current_price,
+                price_target_reasoning="Deviation below threshold",
+            )
+
         # Price above MA -> Sell
         if deviation > 0:
             available_shares = self.available_shares
-            # Calculate position size based on deviation
             quantity = int(available_shares * min(abs(deviation), self.max_position))
-            
+
             if quantity == 0:
                 return TradeDecision(
-                    decision="Hold",
-                    quantity=0,
-                    reasoning="Insufficient shares for mean reversion trade"
-                ).model_dump()
-                
-            return TradeDecision(
+                    orders=[],
+                    replace_decision="Add",
+                    reasoning="Insufficient shares for mean reversion trade",
+                    valuation=current_price,
+                    valuation_reasoning="Using current price as valuation baseline",
+                    price_target=current_price,
+                    price_target_reasoning="Cannot participate",
+                )
+
+            order = OrderDetails(
                 decision="Sell",
                 quantity=quantity,
                 order_type=OrderType.LIMIT,
-                price_limit=current_price * 0.99,  # Accept up to 1% less
-                reasoning=f"Price ${current_price:.2f} above MA ${moving_avg:.2f} by {deviation:.1%}"
-            ).model_dump()
-            
-        # Price below MA -> Buy
-        else:
-            available_cash = self.available_cash
-            max_shares = int(available_cash / current_price)
-            quantity = int(max_shares * min(abs(deviation), self.max_position))
-            
-            if quantity == 0:
-                return TradeDecision(
-                    decision="Hold",
-                    quantity=0,
-                    reasoning="Insufficient cash for mean reversion trade"
-                ).model_dump()
-                
+                price_limit=current_price * 0.99,
+            )
             return TradeDecision(
-                decision="Buy",
-                quantity=quantity,
-                order_type=OrderType.LIMIT,
-                price_limit=current_price * 1.01,  # Pay up to 1% more
-                reasoning=f"Price ${current_price:.2f} below MA ${moving_avg:.2f} by {abs(deviation):.1%}"
-            ).model_dump()
+                orders=[order],
+                replace_decision="Replace",
+                reasoning=f"Price ${current_price:.2f} above MA ${moving_avg:.2f} by {deviation:.1%}",
+                valuation=current_price,
+                valuation_reasoning="Using current price as valuation baseline",
+                price_target=current_price * (1 - min(abs(deviation), 0.05)),
+                price_target_reasoning="Expect reversion toward average",
+            )
+
+        # Price below MA -> Buy
+        available_cash = self.available_cash
+        max_shares = int(available_cash / current_price)
+        quantity = int(max_shares * min(abs(deviation), self.max_position))
+
+        if quantity == 0:
+            return TradeDecision(
+                orders=[],
+                replace_decision="Add",
+                reasoning="Insufficient cash for mean reversion trade",
+                valuation=current_price,
+                valuation_reasoning="Using current price as valuation baseline",
+                price_target=current_price,
+                price_target_reasoning="Cannot participate",
+            )
+
+        order = OrderDetails(
+            decision="Buy",
+            quantity=quantity,
+            order_type=OrderType.LIMIT,
+            price_limit=current_price * 1.01,
+        )
+        return TradeDecision(
+            orders=[order],
+            replace_decision="Replace",
+            reasoning=f"Price ${current_price:.2f} below MA ${moving_avg:.2f} by {abs(deviation):.1%}",
+            valuation=current_price,
+            valuation_reasoning="Using current price as valuation baseline",
+            price_target=current_price * (1 + min(abs(deviation), 0.05)),
+            price_target_reasoning="Expect reversion toward average",
+        )

--- a/src/market/data_recorder.py
+++ b/src/market/data_recorder.py
@@ -53,10 +53,10 @@ class DataRecorder:
         timestamp = datetime.now().isoformat()
         # Calculate aggregate short interest before recording
         short_interest = sum(
-            max(0, -self.agent_repository.get_agent_state_snapshot(
+            self.agent_repository.get_agent_state_snapshot(
                 agent_id,
                 self.context.current_price
-            ).shares)
+            ).borrowed_shares
             for agent_id in self.agent_repository.get_all_agent_ids()
         )
         self.context.update_short_interest(short_interest)

--- a/src/market/state/market_state_manager.py
+++ b/src/market/state/market_state_manager.py
@@ -102,7 +102,9 @@ class MarketStateManager:
 
         # 2. Process borrow fee payments
         if self.borrow_service:
-            self.borrow_service.process_borrow_fees(round_number, self.context.current_price)
+            borrow_result = self.borrow_service.process_borrow_fees(round_number, self.context.current_price)
+            if borrow_result.total_fee > 0:
+                self.context.record_borrow_fee_payment(borrow_result.total_fee, round_number)
         
         # 3. Process dividend payments if needed
         if self.dividend_service:

--- a/src/market/state/sim_context.py
+++ b/src/market/state/sim_context.py
@@ -18,6 +18,7 @@ class MarketHistory:
     trade_history: List[Dict]
     quote_history: List[Dict]
     short_interest: List[float]
+    borrow_fees_paid: List[float]
 
 class SimulationContext:
     """
@@ -54,7 +55,8 @@ class SimulationContext:
             interest_paid=[],
             trade_history=[],
             quote_history=[],
-            short_interest=[0]
+            short_interest=[0],
+            borrow_fees_paid=[]
         )
         
         # Public market information (observable by all)
@@ -99,6 +101,14 @@ class SimulationContext:
     def record_interest_payment(self, amount: float, round_number: int):
         """Record interest payment"""
         self.market_history.interest_paid.append({
+            'round': round_number,
+            'amount': amount,
+            'timestamp': datetime.now().isoformat()
+        })
+
+    def record_borrow_fee_payment(self, amount: float, round_number: int):
+        """Record borrow fee payment"""
+        self.market_history.borrow_fees_paid.append({
             'round': round_number,
             'amount': amount,
             'timestamp': datetime.now().isoformat()


### PR DESCRIPTION
## Summary
- Allow short selling in prompt templates and market maker instructions
- Fix deterministic agents and accounting to support required fields and borrow fees
- Correct short interest, borrow fee tracking, and round verification logic

## Testing
- `pytest -q`
- `python - <<'PY'
import sys
sys.path.append('src')
from base_sim import BaseSimulation
from scenarios import DEFAULT_PARAMS
agent_params={'allow_short_selling':True,'position_limit':1000000,'initial_cash':1000000.0,'initial_shares':10000,'max_order_size':1000,'borrow_model':{'rate':0.02,'payment_frequency':1},'agent_composition':{'short_sell_trader':2,'buy_to_close_trader':2,'buy_trader':1,'deterministic_market_maker':1},'type_specific_params':{'short_sell_trader':{'initial_shares':0},'buy_to_close_trader':{'initial_shares':0}}}
sim=BaseSimulation(num_rounds=5,initial_price=30.0,fundamental_price=28.0,redemption_value=28.0,agent_params=agent_params,lendable_shares=20000,dividend_params=DEFAULT_PARAMS['DIVIDEND_PARAMS'],interest_params=DEFAULT_PARAMS['INTEREST_MODEL'],borrow_params={'rate':0.02,'payment_frequency':1},hide_fundamental_price=False,sim_type='deterministic_short_test')
try:
    sim.run()
except Exception as e:
    print('simulation error',e)
print('short interest history:',sim.context.market_history.short_interest)
print('borrow fees history:',sim.market_state_manager.borrow_service.borrow_history)
for agent_id in sim.agent_repository.get_all_agent_ids():
    state=sim.agent_repository.get_agent_state_snapshot(agent_id,sim.context.current_price)
    print('agent',agent_id,'shares',state.shares,'borrowed',state.borrowed_shares,'cash',state.cash)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68ac7c316960832f89567f3f62a0bff4