### PR TITLE
Enable messaging for deterministic agents

### DIFF
--- a/src/agents/LLMs/services/llm_services.py
+++ b/src/agents/LLMs/services/llm_services.py
@@ -55,6 +55,7 @@ class LLMService:
                 valuation_reasoning="LLM Hold Agent: Always hold strategy",
                 valuation=0,
                 price_target=0,
+                price_target_reasoning="LLM Hold Agent: Always hold strategy",
                 orders=[],  # Empty list for hold
                 replace_decision="Add",
                 reasoning="LLM Hold Agent: Always hold strategy"

--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Literal
+from typing import Optional, List, Dict, Literal, Any
 import numpy as np
 from market.trade import Trade
 from market.information.information_types import InformationType, InformationSignal, InfoCapability
 from agents.agents_api import TradeDecision
 import logging
 from services.logging_service import LoggingService
+from services.messaging_service import MessagingService
 
 @dataclass
 class AgentType:
@@ -106,6 +107,22 @@ class BaseAgent(ABC):
             'borrow_fee': [],
             'other': []
         }
+
+    def get_last_round_messages(self, round_number: int):
+        """Retrieve broadcast messages from the previous round."""
+        if round_number <= 0:
+            return []
+        return MessagingService.get_messages(round_number - 1)
+
+    def get_message_history(self, round_number: int):
+        """Retrieve all broadcast messages up to the previous round."""
+        if round_number <= 1:
+            return []
+        return MessagingService.get_message_history(round_number - 1)
+
+    def broadcast_message(self, round_number: int, message: Dict[str, Any]):
+        """Broadcast a structured message for other agents to read next round."""
+        MessagingService.add_message(round_number, self.agent_id, message)
 
     def read_state(self):
         """Read and log the current state of the agent."""

--- a/src/agents/deterministic/hold_agent.py
+++ b/src/agents/deterministic/hold_agent.py
@@ -10,7 +10,7 @@ class HoldTrader(BaseAgent):
 
     def make_decision(self, market_state: Dict, history: List, round_number: int) -> TradeDecision:
         current_price = market_state.get('price', 0)
-        return TradeDecision(
+        decision = TradeDecision(
             orders=[],
             replace_decision="Add",
             reasoning="Always hold strategy",
@@ -19,3 +19,9 @@ class HoldTrader(BaseAgent):
             price_target=current_price,
             price_target_reasoning="No expected price change",
         )
+        self.broadcast_message(round_number, {
+            'valuation': decision.valuation,
+            'price_target': decision.price_target,
+            'reasoning': decision.reasoning,
+        })
+        return decision

--- a/src/base_sim.py
+++ b/src/base_sim.py
@@ -46,7 +46,7 @@ class BaseSimulation:
         interest_service (InterestService): The service for managing interest payments.
         lendable_shares (int): Total shares available to borrow for short positions.
     """
-    def __init__(self, 
+    def __init__(self,
                  num_rounds: int,
                  initial_price: float,
                  fundamental_price: float,
@@ -62,6 +62,7 @@ class BaseSimulation:
                  borrow_params: dict = None,
                  infinite_rounds: bool = False,
                  sim_type: str = "default"):
+        SharedServiceFactory.reset()
 
         self.infinite_rounds = infinite_rounds
         # Setup logging with sim_type directory structure

--- a/src/run_base_sim.py
+++ b/src/run_base_sim.py
@@ -645,20 +645,21 @@ def save_plots(simulation, params: dict):
                     save_plot_with_suffix(f'reasoning_wordcloud_{agent_type.lower()}')
             
             # Also keep the overall word cloud
-            plt.figure(figsize=(12, 8))
             all_text = ' '.join(decisions_df['reasoning'].dropna().astype(str))
-            wordcloud = WordCloud(
-                width=1200, 
-                height=800,
-                background_color='white',
-                min_font_size=10
-            ).generate(all_text)
-            
-            plt.imshow(wordcloud, interpolation='bilinear')
-            plt.axis('off')
-            plt.title('Common Terms in All Agent Reasoning')
-            
-            save_plot_with_suffix('reasoning_wordcloud_all')
+            if all_text.strip():
+                plt.figure(figsize=(12, 8))
+                wordcloud = WordCloud(
+                    width=1200,
+                    height=800,
+                    background_color='white',
+                    min_font_size=10
+                ).generate(all_text)
+
+                plt.imshow(wordcloud, interpolation='bilinear')
+                plt.axis('off')
+                plt.title('Common Terms in All Agent Reasoning')
+
+                save_plot_with_suffix('reasoning_wordcloud_all')
 
     # Add valuation analysis plots
     decisions_path = simulation.run_dir / 'structured_decisions.csv'

--- a/src/scenarios.py
+++ b/src/scenarios.py
@@ -628,6 +628,56 @@ SCENARIOS = {
             }
         }
     ),
+    "cascade_test": SimulationScenario(
+        name="cascade_test",
+        description="Subset of optimistic agents broadcast messages to test information cascades",
+        parameters={
+            **DEFAULT_PARAMS,
+            "NUM_ROUNDS": 20,
+            "AGENT_PARAMS": {
+                'allow_short_selling': False,
+                'margin_requirement': 0.5,
+                'borrow_model': {
+                    'rate': 0.01,
+                    'payment_frequency': 1
+                },
+                'position_limit': BASE_POSITION_LIMIT,
+                'initial_cash': BASE_INITIAL_CASH,
+                'initial_shares': BASE_INITIAL_SHARES,
+                'max_order_size': BASE_MAX_ORDER_SIZE,
+                'agent_composition': {
+                    'optimistic': 2,
+                    'value': 4,
+                    'market_maker': 2
+                }
+            }
+        }
+    ),
+    "deterministic_only": SimulationScenario(
+        name="deterministic_only",
+        description="Scenario with only deterministic agents to test messaging integration",
+        parameters={
+            **DEFAULT_PARAMS,
+            "NUM_ROUNDS": 5,
+            "AGENT_PARAMS": {
+                'allow_short_selling': False,
+                'margin_requirement': 0.5,
+                'borrow_model': {
+                    'rate': 0.01,
+                    'payment_frequency': 1
+                },
+                'position_limit': BASE_POSITION_LIMIT,
+                'initial_cash': BASE_INITIAL_CASH,
+                'initial_shares': BASE_INITIAL_SHARES,
+                'max_order_size': BASE_MAX_ORDER_SIZE,
+                'agent_composition': {
+                    'gap_trader': 1,
+                    'momentum_trader': 1,
+                    'hold_trader': 1
+                }
+            }
+        }
+    ),
 }
 
 def get_scenario(scenario_name: str) -> SimulationScenario:
@@ -638,4 +688,4 @@ def get_scenario(scenario_name: str) -> SimulationScenario:
 
 def list_scenarios() -> Dict[str, str]:
     """List all available scenarios and their descriptions"""
-    return {name: scenario.description for name, scenario in SCENARIOS.items()} 
+    return {name: scenario.description for name, scenario in SCENARIOS.items()}

--- a/src/services/messaging_service.py
+++ b/src/services/messaging_service.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict, List
+
+
+class MessagingService:
+    """Simple in-memory broadcast channel for agent messages."""
+
+    _messages: Dict[int, List[dict]] = {}
+
+    @classmethod
+    def get_messages(cls, round_number: int) -> List[dict]:
+        """Return all messages for a given round."""
+        return cls._messages.get(round_number, [])
+
+    @classmethod
+    def add_message(cls, round_number: int, agent_id: str, message: Dict[str, Any]) -> None:
+        """Store a structured message for the specified round."""
+        if not message:
+            return
+        cls._messages.setdefault(round_number, []).append({
+            "agent_id": agent_id,
+            "message": message,
+        })
+
+    @classmethod
+    def get_message_history(cls, up_to_round: int) -> List[dict]:
+        """Return all messages from round 1 through ``up_to_round`` inclusive."""
+        history: List[dict] = []
+        for r in range(1, up_to_round + 1):
+            history.extend(cls.get_messages(r))
+        return history
+
+    @classmethod
+    def reset(cls) -> None:
+        """Clear all stored messages."""
+        cls._messages = {}

--- a/src/services/shared_service_factory.py
+++ b/src/services/shared_service_factory.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from agents.agent_manager.services.commitment_services import CommitmentCalculator
 from agents.agent_manager.services.position_services import PositionCalculator
+from services.messaging_service import MessagingService
 
 class SharedServiceFactory:
     """Factory for services shared across multiple components"""
@@ -36,3 +37,4 @@ class SharedServiceFactory:
         cls._commitment_calculator = None
         cls._position_calculator = None
         cls._order_book = None
+        MessagingService.reset()

--- a/tests/test_deterministic_messaging.py
+++ b/tests/test_deterministic_messaging.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import sys
+
+# add src to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import types
+import logging
+
+
+class _TestLoggingService:
+    @staticmethod
+    def get_logger(name):
+        return logging.getLogger(name)
+
+    @staticmethod
+    def log_agent_state(*args, **kwargs):
+        pass
+
+    @staticmethod
+    def log_validation_error(*args, **kwargs):
+        pass
+
+
+sys.modules.setdefault("services.logging_service", types.ModuleType("services.logging_service"))
+sys.modules["services.logging_service"].LoggingService = _TestLoggingService
+
+from agents.deterministic.hold_agent import HoldTrader
+from services.messaging_service import MessagingService
+
+
+def test_deterministic_agents_persistent_messaging_three_rounds():
+    # ensure clean messaging state
+    MessagingService.reset()
+
+    agent1 = HoldTrader(agent_id="A1")
+    agent2 = HoldTrader(agent_id="A2")
+    market_state = {'price': 100}
+    history = []
+
+    # round 1: agents make decisions and broadcast
+    agent1.make_decision(market_state, history, round_number=1)
+    agent2.make_decision(market_state, history, round_number=1)
+
+    round1_messages = MessagingService.get_messages(1)
+    assert len(round1_messages) == 2
+    assert {m['agent_id'] for m in round1_messages} == {"A1", "A2"}
+
+    # round 2: agents retrieve previous round messages
+    last_msgs_a1 = agent1.get_last_round_messages(round_number=2)
+    last_msgs_a2 = agent2.get_last_round_messages(round_number=2)
+    assert last_msgs_a1 == round1_messages
+    assert last_msgs_a2 == round1_messages
+
+    # round 2: agents act again and broadcast new messages
+    agent1.make_decision(market_state, history, round_number=2)
+    agent2.make_decision(market_state, history, round_number=2)
+    round2_messages = MessagingService.get_messages(2)
+    assert len(round2_messages) == 2
+    assert {m['agent_id'] for m in round2_messages} == {"A1", "A2"}
+
+    # round 3: agents retrieve previous round messages and full history
+    last_msgs_a1_r3 = agent1.get_last_round_messages(round_number=3)
+    last_msgs_a2_r3 = agent2.get_last_round_messages(round_number=3)
+    assert last_msgs_a1_r3 == round2_messages
+    assert last_msgs_a2_r3 == round2_messages
+
+    history_a1 = agent1.get_message_history(round_number=3)
+    history_a2 = agent2.get_message_history(round_number=3)
+    assert history_a1 == round1_messages + round2_messages
+    assert history_a2 == round1_messages + round2_messages
+
+    # round 3: agents act again and broadcast new messages
+    agent1.make_decision(market_state, history, round_number=3)
+    agent2.make_decision(market_state, history, round_number=3)
+    round3_messages = MessagingService.get_messages(3)
+    assert len(round3_messages) == 2
+    assert {m['agent_id'] for m in round3_messages} == {"A1", "A2"}
+
+    # message history should now contain all three rounds
+    full_history_a1 = agent1.get_message_history(round_number=4)
+    full_history_a2 = agent2.get_message_history(round_number=4)
+    assert full_history_a1 == round1_messages + round2_messages + round3_messages
+    assert full_history_a2 == round1_messages + round2_messages + round3_messages


### PR DESCRIPTION
## Summary
- allow agents to fetch broadcast history via `MessagingService.get_message_history` and `BaseAgent.get_message_history`
- verify persistent messaging across three rounds with an extended deterministic-agent test

## Testing
- `pytest -q`
- `MPLBACKEND=Agg python src/run_base_sim.py deterministic_only`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_68ae0fcd2f68832fa86ea3b1643f4c8b)