### PR TITLE
Track realized LLM token usage and API cost per run/cell/sweep (#104)

### DIFF
--- a/src/agents/LLMs/services/llm_services.py
+++ b/src/agents/LLMs/services/llm_services.py
@@ -8,6 +8,7 @@ from agents.agents_api import TradeDecision, OrderDetails
 from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 from scenarios.base import DEFAULT_LLM_BASE_URL, resolve_llm_api_key
+from services.usage_tracker import UsageTracker
 from .schema_features import Feature, FeatureRegistry
 
 logger = logging.getLogger("llm_timing")
@@ -148,6 +149,22 @@ IMPORTANT: This is a MULTI-STOCK scenario. You MUST include stock_id for each or
                 )
                 elapsed = time.time() - start_time
                 logger.warning(f"[LLM_CALL] Agent {request.agent_id} R{request.round_number}: Response in {elapsed:.1f}s")
+                # Record realized token usage (issue #104). attempt+1 counts every
+                # try including the retries that preceded this success. usage may be
+                # absent on some self-hosted endpoints -- default to 0 tokens then.
+                usage = getattr(completion, "usage", None)
+                UsageTracker.record(
+                    round_number=request.round_number,
+                    agent_id=request.agent_id,
+                    model=request.model,
+                    call_type="decision",
+                    prompt_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
+                    completion_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
+                    total_tokens=getattr(usage, "total_tokens", None) if usage else None,
+                    latency_s=elapsed,
+                    attempts=attempt + 1,
+                    success=True,
+                )
                 break  # Success, exit retry loop
             except Exception as e:
                 elapsed = time.time() - start_time
@@ -163,6 +180,17 @@ IMPORTANT: This is a MULTI-STOCK scenario. You MUST include stock_id for each or
                     continue
                 else:
                     logger.warning(f"[LLM_CALL] Agent {request.agent_id} R{request.round_number}: Failed after {max_retries} attempts ({elapsed:.1f}s total)")
+                    # Record the exhausted call so realized call counts still
+                    # reconcile against the estimate. No usage is available.
+                    UsageTracker.record(
+                        round_number=request.round_number,
+                        agent_id=request.agent_id,
+                        model=request.model,
+                        call_type="decision",
+                        latency_s=elapsed,
+                        attempts=max_retries,
+                        success=False,
+                    )
                     raise e
 
         # Get raw response from LLM

--- a/src/aggregate_sweep.py
+++ b/src/aggregate_sweep.py
@@ -28,6 +28,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from services.usage_tracker import aggregate_summaries
+
 
 # Metadata columns prepended to every aggregated row, in order. prompt_family is
 # the clustering key for inference across runs sharing a prompt family (#102).
@@ -89,6 +91,60 @@ def aggregate_file(cells, filename: str) -> pd.DataFrame:
     return pd.concat(frames, ignore_index=True)
 
 
+def write_usage_rollup(cells, out_dir: Path) -> None:
+    """Roll per-cell realized LLM usage up to a sweep total (issue #104).
+
+    Reads the llm_usage summary each cell carries in the manifest (written by
+    run_sweep), writes a per-cell panel (llm_usage_by_cell.csv) and a sweep-total
+    summary (llm_usage_summary.json), and prints the headline tokens/$ figure. A
+    no-op (with a note) for pre-#104 sweeps whose cells lack usage data.
+    """
+    summaries = [c.get("llm_usage") for c in cells if c.get("llm_usage")]
+    if not summaries:
+        print("\nllm_usage: no per-cell usage recorded (pre-#104 sweep?) -- skipping rollup.")
+        return
+
+    rollup = aggregate_summaries(summaries)
+
+    # Per-cell panel: one row per cell with its usage totals + cell metadata.
+    rows = []
+    for cell in cells:
+        u = cell.get("llm_usage")
+        if not u:
+            continue
+        rows.append({
+            "cell_id": cell["cell_id"],
+            "seed": cell.get("seed"),
+            "temperature": cell.get("temperature"),
+            "model": cell.get("model"),
+            "variant": cell.get("variant"),
+            "prompt_family": cell_prompt_family(cell),
+            "calls": u.get("calls", 0),
+            "failed_calls": u.get("failed_calls", 0),
+            "prompt_tokens": u.get("prompt_tokens", 0),
+            "completion_tokens": u.get("completion_tokens", 0),
+            "total_tokens": u.get("total_tokens", 0),
+            "cost_usd": u.get("cost_usd", 0.0),
+            "avg_tokens_per_call": u.get("avg_tokens_per_call", 0.0),
+        })
+    panel_path = out_dir / "llm_usage_by_cell.csv"
+    pd.DataFrame(rows).to_csv(panel_path, index=False)
+
+    summary_path = out_dir / "llm_usage_summary.json"
+    with open(summary_path, "w") as f:
+        json.dump(rollup, f, indent=2)
+
+    print(f"\nllm_usage: {rollup['total_tokens']:,} tokens "
+          f"({rollup['prompt_tokens']:,} in / {rollup['completion_tokens']:,} out), "
+          f"${rollup['cost_usd']:.4f}, {rollup['calls']:,} calls "
+          f"across {rollup['runs_with_usage']} cells")
+    if rollup.get("unpriced_models"):
+        print(f"  [warn] no price-table entry (counted as $0): "
+              f"{', '.join(rollup['unpriced_models'])}")
+    print(f"  -> {panel_path}")
+    print(f"  -> {summary_path}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Aggregate sweep cell CSVs into tidy panels with cell metadata columns.",
@@ -132,6 +188,9 @@ def main():
         panel.to_csv(out_path, index=False)
         print(f"  -> {len(panel)} rows across {panel['cell_id'].nunique() if len(panel) else 0} cells "
               f"written to {out_path}")
+
+    # Roll up realized token/cost usage across cells (issue #104).
+    write_usage_rollup(cells, out_dir)
 
     print(f"\nDone. Panels in {out_dir}")
 

--- a/src/base_sim.py
+++ b/src/base_sim.py
@@ -110,6 +110,14 @@ class BaseSimulation:
                  enable_intra_round_margin_checking: bool = False,
                  news_enabled: bool = False):
         SharedServiceFactory.reset()
+        # Reset per-run LLM token/cost accounting (issue #104). Sweeps call many
+        # runs in one process, so this must clear before the first API call.
+        from services.usage_tracker import UsageTracker
+        UsageTracker.reset()
+
+        # Populated at end of run() from UsageTracker (None if the run made no
+        # LLM calls). run_base_sim merges this into the run's metadata.json.
+        self.llm_usage_summary = None
 
         self.infinite_rounds = infinite_rounds
         # Setup logging with sim_type directory structure
@@ -708,7 +716,25 @@ class BaseSimulation:
                 self.data_recorder.save_simulation_data()
             except Exception as e:
                 LoggingService.log_simulation(f"Failed to save final data: {str(e)}")
+            # Persist realized LLM token/cost accounting (issue #104). Best-effort:
+            # a failure here must not mask a simulation result.
+            try:
+                self._save_llm_usage()
+            except Exception as e:
+                LoggingService.log_simulation(f"Failed to save LLM usage: {str(e)}")
        # Clean up expired orders at end of round
+
+    def _save_llm_usage(self):
+        """Write data/llm_usage.csv and stash the run's usage summary (issue #104).
+
+        No CSV is written for all-deterministic runs (no LLM calls). The summary
+        is left on self.llm_usage_summary for run_base_sim to fold into metadata.
+        """
+        from services.usage_tracker import UsageTracker
+        csv_path = self.data_dir / 'llm_usage.csv'
+        UsageTracker.save_csv(csv_path)
+        summary = UsageTracker.summary()
+        self.llm_usage_summary = summary if summary.get("calls", 0) else None
 
     def _generate_dividend_shocks(self) -> dict:
         """Generate systematic and style-level dividend shocks for the current round.

--- a/src/run_base_sim.py
+++ b/src/run_base_sim.py
@@ -70,6 +70,26 @@ def save_parameters(run_dir: Path, params: dict):
     with open(scenario_dir / 'parameters.json', 'w') as f:
         json.dump(params, f, indent=4)
 
+def write_usage_to_metadata(simulation):
+    """Merge the run's realized LLM usage summary into its metadata.json (#104).
+
+    Adds a top-level "llm_usage" key (tokens, dollars, per-model breakdown) to the
+    metadata written up-front by create_run_directory. No-op for runs that made no
+    LLM calls (all-deterministic scenarios), which leave llm_usage_summary as None.
+    """
+    summary = getattr(simulation, 'llm_usage_summary', None)
+    if not summary:
+        return
+    metadata_path = simulation.run_dir / 'metadata.json'
+    try:
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        metadata = {}
+    metadata['llm_usage'] = summary
+    with open(metadata_path, 'w') as f:
+        json.dump(metadata, f, indent=4)
+
 def save_plots(simulation, params: dict):
     """Save all simulation plots to both run directory and latest_sim"""
     plot_generator = PlotGenerator(simulation)
@@ -247,7 +267,11 @@ def run_scenario(
     save_parameters(simulation.run_dir, params)
     simulation.run()
     save_plots(simulation, params)
-    
+
+    # Fold realized LLM token/cost accounting into metadata.json (issue #104)
+    # before copying to latest_sim, so the copied metadata carries it too.
+    write_usage_to_metadata(simulation)
+
     # Copy all data files to latest_sim
     copy_data_to_latest(simulation)
 

--- a/src/run_sweep.py
+++ b/src/run_sweep.py
@@ -96,6 +96,60 @@ from pathlib import Path
 from scenarios import get_scenario
 from scenarios.base import DEFAULT_LLM_MODEL
 from run_base_sim import run_scenario
+from services.model_pricing import compute_cost
+from services.usage_tracker import aggregate_summaries
+
+
+# Persisted per-model realized averages, used to turn the pre-launch call-count
+# estimate into a tokens/$ estimate (issue #104). Written after every sweep.
+CALIBRATION_PATH = Path('logs') / 'sweeps' / 'calibration.json'
+
+
+def load_calibration() -> dict:
+    """Load the per-model tokens-per-call calibration table (may be empty)."""
+    if CALIBRATION_PATH.exists():
+        try:
+            with open(CALIBRATION_PATH) as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return {}
+    return {}
+
+
+def estimate_tokens_and_cost(model: str, calls: int, calibration: dict):
+    """Turn a cell's estimated call count into estimated tokens/$ via calibration.
+
+    Returns None when the model has no calibration entry yet (first-ever sweep of
+    that model), so the caller can fall back to quoting raw call counts.
+    """
+    cal = calibration.get(model)
+    if not cal:
+        return None
+    in_tok = calls * cal.get("input_per_call", 0.0)
+    out_tok = calls * cal.get("output_per_call", 0.0)
+    return {"tokens": in_tok + out_tok, "cost_usd": compute_cost(model, in_tok, out_tok)}
+
+
+def update_calibration(by_model: dict) -> None:
+    """Overwrite calibration entries with the latest realized per-call averages.
+
+    Latest-wins (not a running blend): the most recent sweep of a model is the
+    best guide to the next one, and keeps the file simple and dependency-free.
+    """
+    cal = load_calibration()
+    for model, stats in by_model.items():
+        calls = stats.get("calls", 0)
+        if not calls:
+            continue
+        cal[model] = {
+            "input_per_call": round(stats.get("prompt_tokens", 0) / calls, 2),
+            "output_per_call": round(stats.get("completion_tokens", 0) / calls, 2),
+            "tokens_per_call": round(stats.get("total_tokens", 0) / calls, 2),
+            "n_calls": calls,
+        }
+    CALIBRATION_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(CALIBRATION_PATH, 'w') as f:
+        json.dump(cal, f, indent=2)
 
 
 def sanitize(value) -> str:
@@ -259,9 +313,14 @@ def main():
     # Cost estimate (per-cell so variant overrides that change call count are honored).
     done_ids = {cid for cid, c in manifest["cells"].items() if c.get("status") == "done"}
     remaining_cells = [c for c in cells if not (args.resume and c["cell_id"] in done_ids)]
+    calibration = load_calibration()
     for c in cells:
         c["est_calls"] = estimate_calls_per_cell(base_params, c["variant_overrides"])
+        c["est_usage"] = estimate_tokens_and_cost(c["model"], c["est_calls"], calibration)
     total_calls = sum(c["est_calls"] for c in remaining_cells)
+    est_usages = [c["est_usage"] for c in remaining_cells if c.get("est_usage")]
+    total_est_tokens = sum(u["tokens"] for u in est_usages)
+    total_est_cost = sum(u["cost_usd"] for u in est_usages)
 
     print(f"\n=== Sweep: {sweep_name} ===")
     print(f"Base scenario : {args.scenario}")
@@ -270,11 +329,19 @@ def main():
     if args.resume and done_ids:
         print(f"Resuming      : {len(done_ids)} already done, {len(remaining_cells)} to run")
     print(f"Est. LLM calls: ~{total_calls} total across {len(remaining_cells)} cells")
+    if est_usages:
+        print(f"Est. tokens/$ : ~{total_est_tokens:,.0f} tokens, ~${total_est_cost:.2f} "
+              f"(from calibration, {len(est_usages)}/{len(remaining_cells)} cells)")
+    else:
+        print("Est. tokens/$ : no calibration yet -- run one sweep to enable token/$ estimates")
     print(f"Output root   : {sweep_root}\n")
     print("Cells to run:")
     for c in remaining_cells:
+        usage_str = ""
+        if c.get("est_usage"):
+            usage_str = f", ~{c['est_usage']['tokens']:,.0f} tok/${c['est_usage']['cost_usd']:.3f}"
         print(f"  - {c['cell_id']}  (seed={c['seed']}, temp={c['temperature']}, "
-              f"model={c['model']}, variant={c['variant']}, ~{c['est_calls']} calls)")
+              f"model={c['model']}, variant={c['variant']}, ~{c['est_calls']} calls{usage_str})")
     print()
 
     if args.dry_run:
@@ -336,7 +403,15 @@ def main():
             )
             cell_record["status"] = "done"
             cell_record["run_dir"] = str(simulation.run_dir)
-            print(f"  -> done: {simulation.run_dir}")
+            # Surface realized token/cost usage in the manifest per cell (#104).
+            usage = getattr(simulation, "llm_usage_summary", None)
+            if usage:
+                cell_record["llm_usage"] = usage
+                print(f"  -> done: {simulation.run_dir} | "
+                      f"{usage['total_tokens']:,} tokens, ${usage['cost_usd']:.4f}, "
+                      f"{usage['calls']} calls")
+            else:
+                print(f"  -> done: {simulation.run_dir}")
         except Exception as e:
             cell_record["status"] = "failed"
             cell_record["error"] = str(e)
@@ -350,7 +425,49 @@ def main():
     done = sum(1 for c in manifest["cells"].values() if c.get("status") == "done")
     failed = sum(1 for c in manifest["cells"].values() if c.get("status") == "failed")
     print(f"\n=== Sweep complete: {done} done, {failed} failed ===")
-    print(f"Manifest: {manifest_path}")
+
+    # Roll up realized usage across all done cells, report totals, and
+    # self-calibrate the estimator for future dry-runs (issue #104).
+    usage_summaries = [c.get("llm_usage") for c in manifest["cells"].values()
+                       if c.get("status") == "done"]
+    rollup = aggregate_summaries(usage_summaries)
+    if rollup["calls"]:
+        # Persist the rollup into the manifest so aggregate_sweep / audits can read it.
+        manifest["llm_usage"] = rollup
+        save_manifest(manifest_path, manifest)
+
+        print(f"\nRealized LLM usage ({rollup['runs_with_usage']} runs):")
+        print(f"  Calls   : {rollup['calls']:,} ({rollup['failed_calls']} failed, "
+              f"{rollup['attempts']:,} attempts incl. retries)")
+        print(f"  Tokens  : {rollup['total_tokens']:,} "
+              f"({rollup['prompt_tokens']:,} in / {rollup['completion_tokens']:,} out)")
+        print(f"  Cost    : ${rollup['cost_usd']:.4f}")
+        print(f"  Avg/call: {rollup['avg_tokens_per_call']:,.1f} tokens")
+        if rollup.get("unpriced_models"):
+            print(f"  [warn] no price-table entry (counted as $0): "
+                  f"{', '.join(rollup['unpriced_models'])}")
+
+        # Self-calibration: estimated vs realized call count. Sum estimates only
+        # over cells that actually contributed realized usage (have an llm_usage
+        # entry), so the ratio's numerator (rollup calls) and denominator stay
+        # apples-to-apples even on resumed / pre-#104 sweeps. Reuse the est_calls
+        # already computed above rather than recomputing.
+        usage_cell_ids = {cid for cid, cc in manifest["cells"].items()
+                          if cc.get("status") == "done" and cc.get("llm_usage")}
+        est_total = sum(c["est_calls"] for c in cells if c["cell_id"] in usage_cell_ids)
+        if est_total:
+            ratio = rollup["calls"] / est_total
+            print(f"  Estimator: predicted ~{est_total} calls, realized {rollup['calls']} "
+                  f"({ratio:.2f}x). Per-model avg tokens/call:")
+            for model, mb in rollup["by_model"].items():
+                print(f"    - {model}: {mb['avg_tokens_per_call']:,.1f} tok/call "
+                      f"({mb['avg_prompt_tokens_per_call']:,.1f} in / "
+                      f"{mb['avg_completion_tokens_per_call']:,.1f} out)")
+
+        update_calibration(rollup["by_model"])
+        print(f"  Calibration updated: {CALIBRATION_PATH}")
+
+    print(f"\nManifest: {manifest_path}")
     print(f"Aggregate with: python src/aggregate_sweep.py {sweep_root}")
 
 

--- a/src/services/model_pricing.py
+++ b/src/services/model_pricing.py
@@ -1,0 +1,172 @@
+"""
+Static, dependency-free price table for LLM token usage (issue #104).
+
+Prices are USD per 1,000,000 tokens as (input, output). There are no live pricing
+lookups and no network dependency -- update the numbers here when provider prices
+change. Values are estimates, not invoices; verify against your provider dashboard.
+
+Backend-aware pricing
+---------------------
+The dollar cost of an OPEN-WEIGHT model (gpt-oss-*, llama-*) depends on WHO serves
+it, not just its name. The exact same "gpt-oss-120b" is:
+  - free at the margin when self-hosted (local vLLM) or on the UF Hypergator API,
+  - billed per token on a paid host like DeepInfra.
+So open-model rates are grouped by backend and the active backend is inferred from
+DEFAULT_LLM_BASE_URL at cost-computation time (deepinfra vs. self-hosted). First-
+party OpenAI models (gpt-4o, o3, ...) are billed by OpenAI regardless of base_url,
+so they sit in a single backend-independent table.
+
+Model-name matching is exact first, then longest-prefix, then longest-substring,
+over both the raw name and its provider-stripped, lowercased form -- so
+"openai/gpt-oss-120b-Turbo" resolves to "gpt-oss-120b" (DeepInfra prices the Turbo
+endpoint at the same per-token rate as the base model) and "gpt-4o-2024-08-06"
+resolves to "gpt-4o". Only specific versioned open-model keys are listed (no bare
+"gpt-oss"/"llama" catch-all), so an unrecognized variant is reported as unpriced
+rather than silently costed at $0.
+
+Sources (verified 2026-07, DeepInfra standard tier): gpt-oss-120b $0.037/$0.17,
+gpt-oss-20b $0.03/$0.14 (deepinfra.com model pages); llama-3.3-70b $0.10/$0.32,
+llama-3.1-70b $0.23/$0.40 (deepinfra.com/pricing). DeepInfra's Priority tier is
+~1.5x; adjust if you use it.
+"""
+
+from typing import Dict, Optional, Tuple
+
+# First-party OpenAI models: billed by OpenAI no matter which base_url is set.
+OPENAI_PRICING: Dict[str, Tuple[float, float]] = {
+    "gpt-4o": (2.50, 10.00),
+    "gpt-4o-mini": (0.15, 0.60),
+    "gpt-4.1": (2.00, 8.00),
+    "gpt-4.1-mini": (0.40, 1.60),
+    "gpt-4.1-nano": (0.10, 0.40),
+    "gpt-4-turbo": (10.00, 30.00),
+    "gpt-4": (30.00, 60.00),
+    "gpt-3.5-turbo": (0.50, 1.50),
+    "o3": (2.00, 8.00),
+    "o3-mini": (1.10, 4.40),
+    "o4-mini": (1.10, 4.40),
+    "o1": (15.00, 60.00),
+    "o1-mini": (1.10, 4.40),
+}
+
+# Open-weight models, priced per serving backend. Only specific versioned keys --
+# no bare "gpt-oss"/"llama" catch-all -- so unknown variants surface as unpriced.
+# hold_llm short-circuits before any API call, so it is free on every backend.
+_SELF_HOSTED_OPEN = {
+    "gpt-oss-120b": (0.0, 0.0),
+    "gpt-oss-20b": (0.0, 0.0),
+    "llama-3.3-70b": (0.0, 0.0),
+    "llama-3.1-70b": (0.0, 0.0),
+    "llama-3.1-8b": (0.0, 0.0),
+    "gemma-4-31b": (0.0, 0.0),
+    "gemma-4-26b": (0.0, 0.0),
+    "deepseek-v4-flash": (0.0, 0.0),
+    "nemotron-3-nano-omni-30b": (0.0, 0.0),
+    "hold_llm": (0.0, 0.0),
+}
+_DEEPINFRA_OPEN = {
+    "gpt-oss-120b": (0.037, 0.17),
+    "gpt-oss-20b": (0.03, 0.14),
+    "llama-3.3-70b": (0.10, 0.32),
+    "llama-3.1-70b": (0.23, 0.40),
+    "llama-3.1-8b": (0.03, 0.05),
+    # Gemma 4 family (DeepInfra): 31B dense and 26B-A4B MoE, both ~$0.07/$0.34.
+    # 26B is from DeepInfra's own blog; 31B matches aggregators but its DeepInfra
+    # model page didn't resolve to confirm -- verify on the dashboard if used.
+    "gemma-4-31b": (0.07, 0.34),
+    "gemma-4-26b": (0.07, 0.34),
+    # DeepSeek V4 Flash: cached input is far cheaper ($0.018/1M) but we bill all
+    # input at the full rate since usage.prompt_tokens_details cache hits aren't
+    # tracked here -- a small overestimate when long prompt prefixes are cached.
+    "deepseek-v4-flash": (0.09, 0.18),
+    # NVIDIA Nemotron 3 Nano Omni 30B-A3B (Reasoning), DeepInfra standard tier.
+    # A reasoning model: expect high output-token counts, so the $0.80 output rate
+    # dominates. Key matches the -A3B-Reasoning variant by longest-prefix.
+    "nemotron-3-nano-omni-30b": (0.20, 0.80),
+    "hold_llm": (0.0, 0.0),
+}
+OPEN_MODEL_PRICING: Dict[str, Dict[str, Tuple[float, float]]] = {
+    "self_hosted": _SELF_HOSTED_OPEN,
+    "deepinfra": _DEEPINFRA_OPEN,
+}
+
+
+def active_backend() -> str:
+    """Infer the serving backend from the configured LLM base URL.
+
+    Returns "deepinfra" when DEFAULT_LLM_BASE_URL points at DeepInfra, else
+    "self_hosted" (UF Hypergator API, local vLLM, or unset). Resolved lazily so
+    importing this module never forces scenarios.base to load, and so a run picks
+    up whatever backend is configured when the cost is computed.
+    """
+    try:
+        from scenarios.base import DEFAULT_LLM_BASE_URL
+    except Exception:
+        return "self_hosted"
+    url = (DEFAULT_LLM_BASE_URL or "").lower()
+    if "deepinfra" in url:
+        return "deepinfra"
+    return "self_hosted"
+
+
+def _name_variants(model: str):
+    """The raw lowercased name plus, if present, its provider-stripped form
+    ("openai/gpt-oss-120b-Turbo" -> "gpt-oss-120b-turbo")."""
+    lowered = model.lower()
+    variants = [lowered]
+    if "/" in lowered:
+        variants.append(lowered.rsplit("/", 1)[1])
+    return variants
+
+
+def _lookup(variants, table: Dict[str, Tuple[float, float]]) -> Optional[Tuple[float, float]]:
+    """Exact -> longest-prefix -> longest-substring match of any variant in table."""
+    for name in variants:
+        if name in table:
+            return table[name]
+    for name in variants:
+        pref = [k for k in table if name.startswith(k)]
+        if pref:
+            return table[max(pref, key=len)]
+    for name in variants:
+        sub = [k for k in table if k in name]
+        if sub:
+            return table[max(sub, key=len)]
+    return None
+
+
+def price_for(model: str, backend: Optional[str] = None) -> Optional[Tuple[float, float]]:
+    """Return (input_per_1M, output_per_1M) for `model`, or None if unknown.
+
+    OpenAI first-party models match the backend-independent table; open-weight
+    models match the active backend's table (auto-detected when `backend` is None).
+    None means no table entry -- callers treat dollar cost as 0 but should flag the
+    model as unpriced so the omission is visible.
+    """
+    if not model:
+        return None
+    variants = _name_variants(model)
+    hit = _lookup(variants, OPENAI_PRICING)
+    if hit is not None:
+        return hit
+    backend = backend or active_backend()
+    return _lookup(variants, OPEN_MODEL_PRICING.get(backend, _SELF_HOSTED_OPEN))
+
+
+def is_known_model(model: str, backend: Optional[str] = None) -> bool:
+    """True if the model has a price-table entry for the (active) backend."""
+    return price_for(model, backend) is not None
+
+
+def compute_cost(model: str, prompt_tokens: int, completion_tokens: int,
+                 backend: Optional[str] = None) -> float:
+    """Dollar cost of a call. Unknown models cost 0.0 (flag them via is_known_model).
+
+    Backend defaults to the configured one, so on a DeepInfra deployment gpt-oss/
+    llama calls carry their real per-token cost, while on UF/local they stay $0.
+    """
+    price = price_for(model, backend)
+    if price is None:
+        return 0.0
+    in_rate, out_rate = price
+    return (prompt_tokens / 1_000_000.0) * in_rate + (completion_tokens / 1_000_000.0) * out_rate

--- a/src/services/news_service.py
+++ b/src/services/news_service.py
@@ -22,10 +22,12 @@ from typing import List, Dict, Any, Optional, Literal
 from pydantic import BaseModel, Field, field_validator
 from dataclasses import dataclass
 import openai
+import time
 import logging
 from dotenv import load_dotenv
 
 from scenarios.base import DEFAULT_LLM_BASE_URL, DEFAULT_LLM_MODEL, resolve_llm_api_key
+from services.usage_tracker import UsageTracker
 
 logger = logging.getLogger(__name__)
 
@@ -254,11 +256,16 @@ class NewsService:
             round_number, total_rounds, market_state, price_history, stock_id
         )
 
+        logger.debug(f"[NEWS] Generating news for round {round_number}")
+
+        # Split API call from response parsing so usage is recorded exactly once
+        # (#104): a failure *after* a successful call (bad/empty parse) must not
+        # also append a success=False row for the same call. Prompt building stays
+        # inside this first try so its failure is still swallowed (return []) as
+        # before, rather than propagating to callers that don't catch it.
         try:
             user_prompt = create_news_user_prompt(context)
-
-            logger.debug(f"[NEWS] Generating news for round {round_number}")
-
+            _t0 = time.time()
             completion = self.client.beta.chat.completions.parse(
                 model=self.config.model,
                 messages=[
@@ -268,7 +275,14 @@ class NewsService:
                 response_format=NewsGenerationOutput,
                 temperature=0.7,  # Some creativity for varied news
             )
+        except Exception as e:
+            logger.warning(f"[NEWS] Failed to generate news: {e}")
+            self._record_usage(round_number, None, 0.0, success=False)
+            return []
 
+        self._record_usage(round_number, completion, time.time() - _t0)
+
+        try:
             parsed = completion.choices[0].message.parsed
             news_items = parsed.news_items[:self.config.max_items_per_round]
 
@@ -277,9 +291,8 @@ class NewsService:
                 logger.debug(f"[NEWS]   - {item.headline} ({item.sentiment}, {item.magnitude})")
 
             return news_items
-
         except Exception as e:
-            logger.warning(f"[NEWS] Failed to generate news: {e}")
+            logger.warning(f"[NEWS] Failed to parse news response: {e}")
             return []
 
     def generate_news_multi_stock(
@@ -325,11 +338,14 @@ class NewsService:
                 'last_dividend': dividend.get('last_paid_dividend'),
             }
 
+        logger.debug(f"[NEWS] Generating multi-stock news for round {round_number} ({len(stocks_data)} stocks)")
+
+        # See generate_news: record usage once, keyed on the API call succeeding,
+        # not on the parse succeeding (#104). Prompt building stays inside this
+        # first try so its failure is swallowed as before.
         try:
             user_prompt = create_news_user_prompt(context)
-
-            logger.debug(f"[NEWS] Generating multi-stock news for round {round_number} ({len(stocks_data)} stocks)")
-
+            _t0 = time.time()
             completion = self.client.beta.chat.completions.parse(
                 model=self.config.model,
                 messages=[
@@ -339,7 +355,14 @@ class NewsService:
                 response_format=NewsGenerationOutput,
                 temperature=0.7,
             )
+        except Exception as e:
+            logger.warning(f"[NEWS] Failed to generate multi-stock news: {e}")
+            self._record_usage(round_number, None, 0.0, success=False)
+            return []
 
+        self._record_usage(round_number, completion, time.time() - _t0)
+
+        try:
             parsed = completion.choices[0].message.parsed
             news_items = parsed.news_items[:self.config.max_items_per_round]
 
@@ -349,10 +372,33 @@ class NewsService:
                 logger.debug(f"[NEWS]   - [{stocks_str}] {item.headline}")
 
             return news_items
-
         except Exception as e:
-            logger.warning(f"[NEWS] Failed to generate multi-stock news: {e}")
+            logger.warning(f"[NEWS] Failed to parse multi-stock news response: {e}")
             return []
+
+    def _record_usage(self, round_number: int, completion, latency_s: float, success: bool = True) -> None:
+        """Feed a news-generation call into the run's UsageTracker (issue #104).
+
+        agent_id is the sentinel "__news__" and call_type is "news" so news cost
+        is separable from trading-agent cost in the per-run breakdown. Best-effort:
+        accounting must never break news generation.
+        """
+        try:
+            usage = getattr(completion, "usage", None) if completion is not None else None
+            UsageTracker.record(
+                round_number=round_number,
+                agent_id="__news__",
+                model=self.config.model,
+                call_type="news",
+                prompt_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
+                completion_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
+                total_tokens=getattr(usage, "total_tokens", None) if usage else None,
+                latency_s=latency_s,
+                attempts=1,
+                success=success,
+            )
+        except Exception:  # pragma: no cover - accounting must not break news
+            pass
 
     def _prepare_public_context(
         self,

--- a/src/services/usage_tracker.py
+++ b/src/services/usage_tracker.py
@@ -1,0 +1,221 @@
+"""
+Thread-safe, per-run accumulator for realized LLM token usage and API cost (#104).
+
+Design mirrors LoggingService: a process-global class with class-level state that
+is reset() at the start of every run. Both the trading-agent call path
+(agents/LLMs/services/llm_services.py) and the news generator
+(services/news_service.py) write directly into it, so a single tracker sees every
+API call in a run even though each LLMAgent owns its own LLMService instance and
+decisions are collected on a ThreadPoolExecutor. All mutation goes through a lock
+because agent decisions run in parallel.
+
+At the end of a run BaseSimulation writes data/llm_usage.csv (per-call rows) and
+stashes summary() into the run's metadata.json; run_sweep / aggregate_sweep roll
+those per-cell summaries up to sweep totals.
+"""
+
+import csv
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from services.model_pricing import active_backend, compute_cost, is_known_model
+
+# Per-call CSV columns, in order.
+CSV_FIELDS = [
+    "round", "agent_id", "model", "call_type",
+    "prompt_tokens", "completion_tokens", "total_tokens",
+    "cost_usd", "latency_s", "attempts", "success",
+]
+
+# Scalar fields summed when rolling per-run summaries up to a sweep total.
+_SUMMABLE = [
+    "calls", "successful_calls", "failed_calls", "attempts",
+    "prompt_tokens", "completion_tokens", "total_tokens", "cost_usd",
+]
+
+
+def _empty_totals() -> Dict[str, Any]:
+    return {k: 0 for k in _SUMMABLE}
+
+
+def _add_summable(dst: Dict[str, Any], src: Dict[str, Any]) -> None:
+    for k in _SUMMABLE:
+        dst[k] = dst.get(k, 0) + (src.get(k, 0) or 0)
+
+
+def _with_averages(b: Dict[str, Any]) -> Dict[str, Any]:
+    calls = b.get("calls", 0)
+    b["cost_usd"] = round(b.get("cost_usd", 0.0), 6)
+    b["avg_tokens_per_call"] = round(b["total_tokens"] / calls, 1) if calls else 0.0
+    b["avg_prompt_tokens_per_call"] = round(b["prompt_tokens"] / calls, 1) if calls else 0.0
+    b["avg_completion_tokens_per_call"] = round(b["completion_tokens"] / calls, 1) if calls else 0.0
+    return b
+
+
+def aggregate_summaries(summaries: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Roll a list of per-run summary() dicts up into one combined summary.
+
+    Shared by run_sweep (in-process, from simulation objects) and aggregate_sweep
+    (from manifest cell records), so sweep totals are computed one way. Ignores
+    None/empty entries (runs with no LLM calls).
+    """
+    totals = _empty_totals()
+    by_model: Dict[str, Dict[str, Any]] = {}
+    by_call_type: Dict[str, Dict[str, Any]] = {}
+    unpriced: set = set()
+    backends: set = set()
+    runs_with_usage = 0
+
+    for s in summaries:
+        if not s or not s.get("calls"):
+            continue
+        runs_with_usage += 1
+        _add_summable(totals, s)
+        for m, mb in (s.get("by_model") or {}).items():
+            _add_summable(by_model.setdefault(m, _empty_totals()), mb)
+        for t, tb in (s.get("by_call_type") or {}).items():
+            _add_summable(by_call_type.setdefault(t, _empty_totals()), tb)
+        unpriced.update(s.get("unpriced_models") or [])
+        if s.get("pricing_backend"):
+            backends.add(s["pricing_backend"])
+
+    _with_averages(totals)
+    for b in by_model.values():
+        _with_averages(b)
+    for b in by_call_type.values():
+        _with_averages(b)
+
+    totals["by_model"] = by_model
+    totals["by_call_type"] = by_call_type
+    totals["unpriced_models"] = sorted(unpriced)
+    # Usually one backend across a sweep; join if a sweep somehow mixed backends.
+    totals["pricing_backend"] = "+".join(sorted(backends)) if backends else active_backend()
+    totals["runs_with_usage"] = runs_with_usage
+    return totals
+
+
+class UsageTracker:
+    """Process-global, thread-safe LLM usage accumulator (reset per run)."""
+
+    _lock = threading.Lock()
+    _records: List[Dict[str, Any]] = []
+
+    @classmethod
+    def reset(cls) -> None:
+        """Clear all records. Call once at the start of each simulation run."""
+        with cls._lock:
+            cls._records = []
+
+    @classmethod
+    def record(
+        cls,
+        *,
+        round_number: int,
+        agent_id: str,
+        model: str,
+        call_type: str = "decision",
+        prompt_tokens: Optional[int] = 0,
+        completion_tokens: Optional[int] = 0,
+        total_tokens: Optional[int] = None,
+        latency_s: float = 0.0,
+        attempts: int = 1,
+        success: bool = True,
+    ) -> None:
+        """Record a single LLM API call (one row of llm_usage.csv).
+
+        `attempts` counts every try including retries, not just the successful
+        one. Token counts may be 0 when the endpoint omits usage or the call
+        failed before returning any (a failed call is still recorded, with
+        success=False, so the realized-vs-estimated call count reconciles).
+        """
+        pt = int(prompt_tokens or 0)
+        ct = int(completion_tokens or 0)
+        tt = int(total_tokens) if total_tokens is not None else pt + ct
+        rec = {
+            "round": round_number,
+            "agent_id": agent_id,
+            "model": model,
+            "call_type": call_type,
+            "prompt_tokens": pt,
+            "completion_tokens": ct,
+            "total_tokens": tt,
+            "cost_usd": round(compute_cost(model, pt, ct), 6),
+            "latency_s": round(float(latency_s), 3),
+            "attempts": int(attempts),
+            "success": bool(success),
+        }
+        with cls._lock:
+            cls._records.append(rec)
+
+    @classmethod
+    def records(cls) -> List[Dict[str, Any]]:
+        """Snapshot copy of all recorded calls."""
+        with cls._lock:
+            return list(cls._records)
+
+    @classmethod
+    def summary(cls) -> Dict[str, Any]:
+        """Aggregate all recorded calls into run totals + per-model breakdown.
+
+        Returned dict is JSON-serializable and safe to drop into metadata.json.
+        """
+        recs = cls.records()
+
+        totals = _empty_totals()
+        by_model: Dict[str, Dict[str, Any]] = {}
+        by_call_type: Dict[str, Dict[str, Any]] = {}
+        unpriced: set = set()
+
+        for r in recs:
+            row = {
+                "calls": 1,
+                "successful_calls": 1 if r["success"] else 0,
+                "failed_calls": 0 if r["success"] else 1,
+                "attempts": r["attempts"],
+                "prompt_tokens": r["prompt_tokens"],
+                "completion_tokens": r["completion_tokens"],
+                "total_tokens": r["total_tokens"],
+                "cost_usd": r["cost_usd"],
+            }
+            _add_summable(totals, row)
+            _add_summable(by_model.setdefault(r["model"], _empty_totals()), row)
+            _add_summable(by_call_type.setdefault(r["call_type"], _empty_totals()), row)
+            if r["total_tokens"] and not is_known_model(r["model"]):
+                unpriced.add(r["model"])
+
+        _with_averages(totals)
+        for b in by_model.values():
+            _with_averages(b)
+        for b in by_call_type.values():
+            _with_averages(b)
+
+        totals["by_model"] = by_model
+        totals["by_call_type"] = by_call_type
+        # Which backend's price table produced cost_usd (deepinfra vs self_hosted),
+        # so the dollar figure is auditable -- the same model is free self-hosted
+        # but billed on DeepInfra.
+        totals["pricing_backend"] = active_backend()
+        # Models that had real token usage but no price-table entry: their dollar
+        # figure is understated (counted as 0). Surface them so it is not silent.
+        totals["unpriced_models"] = sorted(unpriced)
+        return totals
+
+    @classmethod
+    def save_csv(cls, path) -> Optional[Path]:
+        """Write per-call rows to `path`. Returns the path, or None if no calls.
+
+        Dependency-free (stdlib csv). No file is written when a run made no LLM
+        calls (e.g. an all-deterministic scenario), to avoid empty artifacts.
+        """
+        recs = cls.records()
+        if not recs:
+            return None
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=CSV_FIELDS)
+            writer.writeheader()
+            for r in recs:
+                writer.writerow({k: r[k] for k in CSV_FIELDS})
+        return path


### PR DESCRIPTION
## Summary

Realized LLM usage was previously discarded (`llm_services.py` dropped `completion.usage` on every call), so there was no token or dollar accounting anywhere. This adds end-to-end, **backend-aware** token + cost tracking at every level: per run, per sweep cell, and rolled up across a sweep.

## What's included

**New modules**
- `services/model_pricing.py` — static, dependency-free USD/1M-token price table. Backend-aware: open-weight models (gpt-oss, llama, gemma-4, deepseek-v4-flash, nemotron) are $0 self-hosted (UF/local vLLM) but billed per token on DeepInfra; backend inferred from `DEFAULT_LLM_BASE_URL`. OpenAI models are backend-independent. Name matching tolerates provider prefixes/suffixes (`openai/gpt-oss-120b-Turbo` → `gpt-oss-120b`). Only specific versioned keys, so unknown variants surface as **unpriced** rather than silently $0.
- `services/usage_tracker.py` — thread-safe process-global accumulator (mirrors `LoggingService`), reset per run; safe under the decision `ThreadPoolExecutor`. Both the agent path and news generator record into it.

**Wired in**
- `llm_services.py`: capture `completion.usage` on success (counting all attempts incl. retries) + record exhausted-retry failures.
- `news_service.py`: record both news call sites; API call and parse split so usage is recorded exactly once.
- `base_sim.py`: reset per run, write `data/llm_usage.csv`, stash summary.
- `run_base_sim.py`: fold summary into `metadata.json`.
- `run_sweep.py`: per-cell usage in the manifest, end-of-sweep tokens/$ roll-up, self-calibration → calibration file so `--dry-run` quotes tokens/$.
- `aggregate_sweep.py`: sweep-wide roll-up → `llm_usage_summary.json` + `llm_usage_by_cell.csv`.

## Verification
- Unit + full suite (**175 pass**).
- End-to-end run with a patched network layer (CSV + metadata populated, tokens/cost correct).
- **Live DeepInfra calls** (gpt-oss-120b, Nemotron): usage returned, cost cross-checked against the price table exactly, backend correctly detected.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)